### PR TITLE
Small fixes suggested by go vet

### DIFF
--- a/blobstore_test.go
+++ b/blobstore_test.go
@@ -93,8 +93,8 @@ func TestCheckedReader(t *testing.T) {
 			toKeyOrDie(t, testCase.expectedHash),
 			sha1.New()}
 		err = readAll(badReader)
-		assert(strings.Contains(err.Error(), CorruptedBlobErrorPrefix), t,
-			"An %s error was expected, but we got %s instead", CorruptedBlobErrorPrefix, err)
+		assert(strings.Contains(err.Error(), corruptedBlobErrorPrefix), t,
+			"An %s error was expected, but we got %s instead", corruptedBlobErrorPrefix, err)
 	}
 }
 

--- a/blobstore_test.go
+++ b/blobstore_test.go
@@ -104,7 +104,7 @@ func TestFileReadsNWrites(t *testing.T) {
 	// prepare a root for the blob store filesystem with a random name and a file blobserver on it
 	dir := fileBlobs{""}.TmpKeyname(10)
 	os.Mkdir(dir, 0700)
-	fileBlobs := NewFileBlobStoreAdmin(dir, crypto.SHA1)
+	fileBlobs := NewFileBlobAdmin(dir, crypto.SHA1)
 	// exercise
 	readsNWrites(t, fileBlobs)
 	// cleanup
@@ -116,13 +116,13 @@ func TestFileReadsNWrites(t *testing.T) {
 // TestMemReadsNWrites test that the in-memory blobserver does its reads and writes as expected
 func TestMemReadsNWrites(t *testing.T) {
 	// setup
-	memBlobs := NewMemBlobStoreAdmin(crypto.SHA1)
+	memBlobs := NewMemBlobAdmin(crypto.SHA1)
 	// exercise
 	readsNWrites(t, memBlobs)
 }
 
 // readsNWrites exercises a read, write, read, write, remove, read sequence from testData into a BlobStoreAdmin
-func readsNWrites(t *testing.T, blobs BlobStoreAdmin) {
+func readsNWrites(t *testing.T, blobs BlobAdmin) {
 	for _, testCase := range testData {
 		expectedKey := toKeyOrDie(t, testCase.expectedHash)
 		// 1 read must fail
@@ -173,7 +173,7 @@ func readsNWrites(t *testing.T, blobs BlobStoreAdmin) {
 // TestMemList test that the in-memory list call returns all stored keys as expected
 func TestMemList(t *testing.T) {
 	// setup
-	memBlobs := NewMemBlobStoreAdmin(crypto.SHA1)
+	memBlobs := NewMemBlobAdmin(crypto.SHA1)
 	expectedKeys := buildExpectedKeysList()
 	// exercise
 	listChecks(t, expectedKeys, memBlobs)

--- a/checkedreader.go
+++ b/checkedreader.go
@@ -24,7 +24,7 @@ func (cr *checkedReader) Read(buf []byte) (n int, err error) {
 	if err != nil && err == io.EOF {
 		actualKey := Key(cr.hasher.Sum(nil))
 		if !cr.key.Equals(actualKey) {
-			return n, fmt.Errorf("%s expected hash was %v but got %v", CorruptedBlobErrorPrefix, cr.key, actualKey)
+			return n, fmt.Errorf("%s expected hash was %v but got %v", corruptedBlobErrorPrefix, cr.key, actualKey)
 		}
 	}
 	return n, err

--- a/checkedreader.go
+++ b/checkedreader.go
@@ -24,7 +24,7 @@ func (cr *checkedReader) Read(buf []byte) (n int, err error) {
 	if err != nil && err == io.EOF {
 		actualKey := Key(cr.hasher.Sum(nil))
 		if !cr.key.Equals(actualKey) {
-			return n, fmt.Errorf("%s expected hash was %v but got %v!!", CorruptedBlobErrorPrefix, cr.key, actualKey)
+			return n, fmt.Errorf("%s expected hash was %v but got %v", CorruptedBlobErrorPrefix, cr.key, actualKey)
 		}
 	}
 	return n, err

--- a/checkedreader.go
+++ b/checkedreader.go
@@ -14,7 +14,8 @@ type checkedReader struct {
 	hasher hash.Hash
 }
 
-// Read will return an error prefixed by 'CorruptedBlobErrorPrefix' if the readed blob did not match the hash key
+// Read will return an error prefixed by 'CorruptedBlobErrorPrefix',
+// if the readed blob did not match the hash key
 func (cr *checkedReader) Read(buf []byte) (n int, err error) {
 	n, err = cr.Reader.Read(buf)
 	if n > 0 {

--- a/doc.go
+++ b/doc.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	CorruptedBlobErrorPrefix = "Corrupted Blob:"
-	FilesAtOnce              = 10
 )
 
 // Key is the blob key type

--- a/doc.go
+++ b/doc.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	CorruptedBlobErrorPrefix = "Corrupted Blob:"
+	corruptedBlobErrorPrefix = "Corrupted Blob:"
 )
 
 // Key is the blob key type

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Package blobserver a Content Addressed basic service definition an implementation
+Package blobstore a Content Addressed basic service definition an implementation
 
 The normal BlobStore user interface allows just to:
 - Read a blob or stream of bytes given its content based hash key (for instance SHA-1 of all the bytes)
@@ -24,7 +24,7 @@ const (
 	FilesAtOnce              = 10
 )
 
-// A blob key
+// Key is the blob key type
 type Key []byte
 
 // String returns the hexadecimal string representation of the key
@@ -37,7 +37,7 @@ func (k Key) Equals(key Key) bool {
 	return bytes.Compare(k, key) == 0
 }
 
-// A Key or Error type for key listing
+// KeyOrError type for key listing
 type KeyOrError struct {
 	key Key
 	err error

--- a/doc.go
+++ b/doc.go
@@ -53,9 +53,9 @@ type BlobStore interface {
 	List() <-chan KeyOrError
 }
 
-// BlobStoreAdmin is a BlobStore that can also remove blobs
+// BlobAdmin is a BlobStore that can also remove blobs
 // usually an elevated piviledges operation that only a Garbage Collector needs to do based on certain policies
-type BlobStoreAdmin interface {
+type BlobAdmin interface {
 	BlobStore
 	// Remove the given key, returns an error is something goes wrong (if the key is not present it does NOT complain)
 	Remove(key Key) error
@@ -66,8 +66,8 @@ func NewFileBlobStore(dir string, hash crypto.Hash) BlobStore {
 	return NewFileBlobServer(dir, hash)
 }
 
-// NewFileBlobStore returns a files BlobStoreAdmin
-func NewFileBlobStoreAdmin(dir string, hash crypto.Hash) BlobStoreAdmin {
+// NewFileBlobAdmin returns a files BlobAdmin
+func NewFileBlobAdmin(dir string, hash crypto.Hash) BlobAdmin {
 	return NewFileBlobServer(dir, hash)
 }
 
@@ -76,7 +76,7 @@ func NewMemBlobStore(hash crypto.Hash) BlobStore {
 	return NewMemBlobServer(hash)
 }
 
-// NewMemBlobStore returns a files BlobStoreAdmin
-func NewMemBlobStoreAdmin(hash crypto.Hash) BlobStoreAdmin {
+// NewMemBlobAdmin returns a files BlobAdmin
+func NewMemBlobAdmin(hash crypto.Hash) BlobAdmin {
 	return NewMemBlobServer(hash)
 }

--- a/memblobs.go
+++ b/memblobs.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	INITIAL_MEM_BUFFER = 10
+	initialMemBuffer = 10
 )
 
 // NewMemBlobServer returns a VFSBlobServer using a fileBlobs, that is on top of the os files
@@ -42,7 +42,7 @@ func (mem *memBlobs) Open(key string) (io.ReadCloser, error) {
 
 // Create a key to set its contents
 func (mem *memBlobs) Create(keyname string) (io.WriteCloser, error) {
-	buf := make([]byte, 0, INITIAL_MEM_BUFFER)
+	buf := make([]byte, 0, initialMemBuffer)
 	mem.blobs[keyname] = bytes.NewBuffer(buf)
 	mem.insert(keyname)
 	return nopWriterCloser(mem.blobs[keyname]), nil

--- a/vfsstore.go
+++ b/vfsstore.go
@@ -7,7 +7,7 @@ import (
 	"io"
 )
 
-// VFS blob server implements a generic BlobServer on a Virtual Filesystem (VirtualFS)
+// VFSBlobServer implements a generic BlobServer on a Virtual Filesystem (VirtualFS)
 type VFSBlobServer struct {
 	VirtualFS
 	hash crypto.Hash


### PR DESCRIPTION
- Fix comments
- Fix constant names
- Rename to avoid stuttering
- Avoid punctuation at end of error
- Hide constant that didn't need exporting